### PR TITLE
[Http-Server] CC-1646: Upgrade Python support to 3.13

### DIFF
--- a/compiled_starters/python/README.md
+++ b/compiled_starters/python/README.md
@@ -30,7 +30,7 @@ Time to move on to the next stage!
 
 Note: This section is for stages 2 and beyond.
 
-1. Ensure you have `python (3.11)` installed locally
+1. Ensure you have `python (3.13)` installed locally
 1. Run `./your_program.sh` to run your program, which is implemented in
    `app/main.py`.
 1. Commit your changes and run `git push origin master` to submit your solution

--- a/compiled_starters/python/codecrafters.yml
+++ b/compiled_starters/python/codecrafters.yml
@@ -7,5 +7,5 @@ debug: false
 # Use this to change the Python version used to run your code
 # on Codecrafters.
 #
-# Available versions: python-3.12
-language_pack: python-3.12
+# Available versions: python-3.13
+language_pack: python-3.13

--- a/dockerfiles/python-3.13.Dockerfile
+++ b/dockerfiles/python-3.13.Dockerfile
@@ -1,0 +1,17 @@
+FROM python:3.13-alpine
+
+RUN pip install --no-cache-dir "pipenv>=2024.4.0"
+
+COPY Pipfile /app/Pipfile
+COPY Pipfile.lock /app/Pipfile.lock
+
+WORKDIR /app
+
+ENV WORKON_HOME=/venvs
+
+RUN pipenv install
+
+# Force environment creation
+RUN pipenv run python3 -c "1+1"
+
+ENV CODECRAFTERS_DEPENDENCY_FILE_PATHS="Pipfile,Pipfile.lock"

--- a/solutions/python/01-at4/code/README.md
+++ b/solutions/python/01-at4/code/README.md
@@ -30,7 +30,7 @@ Time to move on to the next stage!
 
 Note: This section is for stages 2 and beyond.
 
-1. Ensure you have `python (3.11)` installed locally
+1. Ensure you have `python (3.13)` installed locally
 1. Run `./your_program.sh` to run your program, which is implemented in
    `app/main.py`.
 1. Commit your changes and run `git push origin master` to submit your solution

--- a/solutions/python/01-at4/code/codecrafters.yml
+++ b/solutions/python/01-at4/code/codecrafters.yml
@@ -7,5 +7,5 @@ debug: false
 # Use this to change the Python version used to run your code
 # on Codecrafters.
 #
-# Available versions: python-3.12
-language_pack: python-3.12
+# Available versions: python-3.13
+language_pack: python-3.13

--- a/starter_templates/python/config.yml
+++ b/starter_templates/python/config.yml
@@ -1,3 +1,3 @@
 attributes:
-  required_executable: python (3.11)
+  required_executable: python (3.13)
   user_editable_file: app/main.py


### PR DESCRIPTION
Upgrade the Python version in configuration and documentation files to 3.13. Introduce a Dockerfile for setting up a Python 3.13 environment with Pipenv.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated installation instructions to specify the new Python 3.13 requirement.
- **New Features**
	- Introduced a container configuration based on Alpine Linux for Python 3.13.
	- Refreshed configuration files to consistently reflect the new Python version across all setups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->