### PR TITLE
Clarify directory handling in #ap6 Return a file

### DIFF
--- a/stage_descriptions/base-07-ap6.md
+++ b/stage_descriptions/base-07-ap6.md
@@ -1,14 +1,16 @@
 In this stage, you'll implement the `/files/{filename}` endpoint, which returns a requested file to the client.
 
 ### Tests
-The tester will execute your program with a `--directory` flag. The `--directory` flag specifies the directory where the files are stored, as an absolute path.
+
+The tester will execute your program with a `--directory` flag. Your program should read this flag from the command-line arguments, and treat the specified directory as the root directory for all file requests.
+
 ```
 $ ./your_program.sh --directory /tmp/
 ```
 
-The tester will then send two `GET` requests to the `/files/{filename}` endpoint on your server.
+The tester will then send two `GET` requests to the `/files/{filename}` endpoint. Each request corresponds to the file path `/{directory}/{filename}`.
 
-Your response should depend on whether `{filename}` exists in the directory specified by `--directory`.
+Your response should depend on whether the file at `/{directory}/{filename}` exists or not.
 
 #### First request
 The first request will ask for a file that exists in the files directory:

--- a/stage_descriptions/base-07-ap6.md
+++ b/stage_descriptions/base-07-ap6.md
@@ -8,9 +8,9 @@ The tester will execute your program with a `--directory` flag. Your program sho
 $ ./your_program.sh --directory /tmp/
 ```
 
-The tester will then send two `GET` requests to the `/files/{filename}` endpoint. Each request corresponds to the file path `/{directory}/{filename}`.
+The tester will then send two `GET` requests to the `/files/{filename}` endpoint. Each request corresponds to the file path `{directory}/{filename}`.
 
-Your response should depend on whether the file at `/{directory}/{filename}` exists or not.
+Your response should depend on whether the file at `{directory}/{filename}` exists or not.
 
 #### First request
 The first request will ask for a file that exists in the files directory:


### PR DESCRIPTION
Context:

https://backend.codecrafters.io/admin/course_stage_feedback_submissions/058ba330-86eb-4160-9a2a-df5c7dfd3279/edit

<img width="930" height="264" alt="image" src="https://github.com/user-attachments/assets/07530332-63f7-4524-939f-5e5332a5ee33" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that clarifies how file paths are resolved from the `--directory` flag; no runtime behavior is modified.
> 
> **Overview**
> Clarifies the `#ap6` stage instructions for the `/files/{filename}` endpoint by explicitly stating that `--directory` must be read from CLI args and treated as the *root* for all file requests.
> 
> Updates the test description to consistently define requests as mapping to `{directory}/{filename}` and bases `200` vs `404` responses on the existence of that full path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 99dd794f4be4d038c0dddf49ebd298183b487fff. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->