### PR TITLE
Add pkg-config installation to OCaml 5.4 Dockerfile

### DIFF
--- a/dockerfiles/ocaml-5.4.Dockerfile
+++ b/dockerfiles/ocaml-5.4.Dockerfile
@@ -11,6 +11,16 @@ ENV CODECRAFTERS_DEPENDENCY_FILE_PATHS="dune,dune-project,codecrafters_http_serv
 # hadolint ignore=DL3002
 USER root
 
+# hadolint ignore=DL3008
+RUN apt-get update && \
+    apt-get install --no-install-recommends -y \
+        libncurses-dev \
+        libreadline-dev \
+        pkg-config \
+        xz-utils && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
 # Install dune
 RUN opam install dune.3.21.0 --yes
 


### PR DESCRIPTION
Context:

https://forum.codecrafters.io/t/state-df4-pkg-config-required-by-ocaml-package/15921

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adjusts the OCaml 5.4 Docker build to install additional Debian packages before installing dune; no runtime logic changes.
> 
> **Overview**
> Updates the OCaml 5.4 Docker image build to install additional system packages via `apt-get` (notably `pkg-config`, plus `libncurses-dev`, `libreadline-dev`, and `xz-utils`) before installing dune, improving compatibility with native/library dependencies during builds.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b9c4b7e4c716afac73a179a2fe4a50de993c51db. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->