### PR TITLE
CC-2191: Upgrade Ruby to v4

### DIFF
--- a/compiled_starters/ruby/.codecrafters/run.sh
+++ b/compiled_starters/ruby/.codecrafters/run.sh
@@ -8,4 +8,5 @@
 
 set -e # Exit on failure
 
-exec bundle exec ruby app/main.rb "$@"
+export BUNDLE_GEMFILE="$(dirname "$0")/Gemfile"
+exec bundle exec ruby "$(dirname "$0")/app/main.rb" "$@"

--- a/compiled_starters/ruby/README.md
+++ b/compiled_starters/ruby/README.md
@@ -30,7 +30,7 @@ Time to move on to the next stage!
 
 Note: This section is for stages 2 and beyond.
 
-1. Ensure you have `ruby (3.4)` installed locally
+1. Ensure you have `ruby (4.0)` installed locally
 1. Run `./your_program.sh` to run your program, which is implemented in
    `app/main.rb`.
 1. Commit your changes and run `git push origin master` to submit your solution

--- a/compiled_starters/ruby/codecrafters.yml
+++ b/compiled_starters/ruby/codecrafters.yml
@@ -7,5 +7,5 @@ debug: false
 # Use this to change the Ruby version used to run your code
 # on Codecrafters.
 #
-# Available versions: ruby-3.4
-buildpack: ruby-3.4
+# Available versions: ruby-4.0
+buildpack: ruby-4.0

--- a/compiled_starters/ruby/your_program.sh
+++ b/compiled_starters/ruby/your_program.sh
@@ -12,4 +12,5 @@ set -e # Exit early if any commands fail
 #
 # - Edit this to change how your program runs locally
 # - Edit .codecrafters/run.sh to change how your program runs remotely
-exec bundle exec ruby app/main.rb "$@"
+export BUNDLE_GEMFILE="$(dirname "$0")/Gemfile"
+exec bundle exec ruby "$(dirname "$0")/app/main.rb" "$@"

--- a/dockerfiles/ruby-4.0.Dockerfile
+++ b/dockerfiles/ruby-4.0.Dockerfile
@@ -1,0 +1,19 @@
+# syntax=docker/dockerfile:1.7-labs
+FROM ruby:4.0-alpine3.23
+
+# Required for installing the json/async gems
+RUN apk add --no-cache \
+    build-base~=0.5 \
+    libssl3~=3.5 \
+    readline-dev~=8.3 \
+    zlib-dev~=1.3
+
+# Re-build if Gemfile or Gemfile.lock changes
+ENV CODECRAFTERS_DEPENDENCY_FILE_PATHS="Gemfile,Gemfile.lock"
+
+WORKDIR /app
+
+# .git & README.md are unique per-repository. We ignore them on first copy to prevent cache misses
+COPY --exclude=.git --exclude=README.md . /app
+
+RUN bundle install --verbose

--- a/solutions/ruby/01-at4/code/.codecrafters/run.sh
+++ b/solutions/ruby/01-at4/code/.codecrafters/run.sh
@@ -8,4 +8,5 @@
 
 set -e # Exit on failure
 
-exec bundle exec ruby app/main.rb "$@"
+export BUNDLE_GEMFILE="$(dirname "$0")/Gemfile"
+exec bundle exec ruby "$(dirname "$0")/app/main.rb" "$@"

--- a/solutions/ruby/01-at4/code/README.md
+++ b/solutions/ruby/01-at4/code/README.md
@@ -30,7 +30,7 @@ Time to move on to the next stage!
 
 Note: This section is for stages 2 and beyond.
 
-1. Ensure you have `ruby (3.4)` installed locally
+1. Ensure you have `ruby (4.0)` installed locally
 1. Run `./your_program.sh` to run your program, which is implemented in
    `app/main.rb`.
 1. Commit your changes and run `git push origin master` to submit your solution

--- a/solutions/ruby/01-at4/code/codecrafters.yml
+++ b/solutions/ruby/01-at4/code/codecrafters.yml
@@ -7,5 +7,5 @@ debug: false
 # Use this to change the Ruby version used to run your code
 # on Codecrafters.
 #
-# Available versions: ruby-3.4
-buildpack: ruby-3.4
+# Available versions: ruby-4.0
+buildpack: ruby-4.0

--- a/solutions/ruby/01-at4/code/your_program.sh
+++ b/solutions/ruby/01-at4/code/your_program.sh
@@ -12,4 +12,5 @@ set -e # Exit early if any commands fail
 #
 # - Edit this to change how your program runs locally
 # - Edit .codecrafters/run.sh to change how your program runs remotely
-exec bundle exec ruby app/main.rb "$@"
+export BUNDLE_GEMFILE="$(dirname "$0")/Gemfile"
+exec bundle exec ruby "$(dirname "$0")/app/main.rb" "$@"

--- a/starter_templates/ruby/code/.codecrafters/run.sh
+++ b/starter_templates/ruby/code/.codecrafters/run.sh
@@ -8,4 +8,5 @@
 
 set -e # Exit on failure
 
-exec bundle exec ruby app/main.rb "$@"
+export BUNDLE_GEMFILE="$(dirname "$0")/Gemfile"
+exec bundle exec ruby "$(dirname "$0")/app/main.rb" "$@"

--- a/starter_templates/ruby/config.yml
+++ b/starter_templates/ruby/config.yml
@@ -1,3 +1,3 @@
 attributes:
-  required_executable: ruby (3.4)
+  required_executable: ruby (4.0)
   user_editable_file: app/main.rb


### PR DESCRIPTION
CC-2191: Upgrade Ruby to v4

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes the runtime/buildpack version and adds a new Docker image, which can surface gem/native-extension or compatibility issues at build/run time.
> 
> **Overview**
> Upgrades the Ruby starter and example solution environment from **Ruby 3.4 to Ruby 4.0**, updating `codecrafters.yml`, docs, and template metadata to match.
> 
> Updates local/remote run scripts to set `BUNDLE_GEMFILE` and use paths relative to the script location, reducing dependency on the current working directory.
> 
> Adds a new `ruby-4.0` Dockerfile (Alpine-based) to build/install dependencies for the updated runtime.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d86193cd8ac4009544f376928e06b49a68b8bf59. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->