### PR TITLE
CC-2203: Upgrade Odin to dev-2026-04

### DIFF
--- a/compiled_starters/odin/README.md
+++ b/compiled_starters/odin/README.md
@@ -30,7 +30,7 @@ Time to move on to the next stage!
 
 Note: This section is for stages 2 and beyond.
 
-1. Ensure you have `odin (dev-2026-03)` installed locally
+1. Ensure you have `odin (dev-2026-04)` installed locally
 1. Run `./your_program.sh` to run your program, which is implemented in
    `src/main.odin`.
 1. Commit your changes and run `git push origin master` to submit your solution

--- a/compiled_starters/odin/codecrafters.yml
+++ b/compiled_starters/odin/codecrafters.yml
@@ -7,5 +7,5 @@ debug: false
 # Use this to change the Odin version used to run your code
 # on Codecrafters.
 #
-# Available versions: odin-2026.3
-buildpack: odin-2026.3
+# Available versions: odin-2026.4
+buildpack: odin-2026.4

--- a/dockerfiles/odin-2026.4.Dockerfile
+++ b/dockerfiles/odin-2026.4.Dockerfile
@@ -1,0 +1,22 @@
+# syntax=docker/dockerfile:1.7-labs
+FROM silkeh/clang:21-trixie
+
+WORKDIR /Odin-install
+RUN git clone --depth 1 -b dev-2026-04 https://github.com/odin-lang/Odin.git /Odin-install \
+    && git checkout dev-2026-04 \
+    && make
+
+RUN mkdir /opt/Odin \
+    && cp -R ./base ./core ./shared ./vendor ./odin /opt/Odin/
+
+WORKDIR /
+RUN rm -rf /Odin-install
+ENV PATH="/opt/Odin:${PATH}"
+
+WORKDIR /app
+
+# .git & README.md are unique per-repository. We ignore them on first copy to prevent cache misses
+COPY --exclude=.git --exclude=README.md . /app
+
+# Install language-specific dependencies
+RUN .codecrafters/compile.sh

--- a/solutions/odin/01-at4/code/README.md
+++ b/solutions/odin/01-at4/code/README.md
@@ -30,7 +30,7 @@ Time to move on to the next stage!
 
 Note: This section is for stages 2 and beyond.
 
-1. Ensure you have `odin (dev-2026-03)` installed locally
+1. Ensure you have `odin (dev-2026-04)` installed locally
 1. Run `./your_program.sh` to run your program, which is implemented in
    `src/main.odin`.
 1. Commit your changes and run `git push origin master` to submit your solution

--- a/solutions/odin/01-at4/code/codecrafters.yml
+++ b/solutions/odin/01-at4/code/codecrafters.yml
@@ -7,5 +7,5 @@ debug: false
 # Use this to change the Odin version used to run your code
 # on Codecrafters.
 #
-# Available versions: odin-2026.3
-buildpack: odin-2026.3
+# Available versions: odin-2026.4
+buildpack: odin-2026.4

--- a/starter_templates/odin/config.yml
+++ b/starter_templates/odin/config.yml
@@ -1,3 +1,3 @@
 attributes:
-  required_executable: odin (dev-2026-03)
+  required_executable: odin (dev-2026-04)
   user_editable_file: src/main.odin


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Upgrades the Odin compiler/buildpack version, which can affect compilation and runtime behavior for all Odin submissions. Risk is mainly build/compatibility regressions from the new upstream snapshot.
> 
> **Overview**
> Updates the Odin HTTP-server starter and template configs to require and run against `odin (dev-2026-04)`, including switching `codecrafters.yml` buildpack references from `odin-2026.3` to `odin-2026.4`.
> 
> Adds a new `dockerfiles/odin-2026.4.Dockerfile` that builds Odin from the `dev-2026-04` branch and installs it into the runtime image.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 98f17b8aa11a9b3a9ec00759298994a0c0209098. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->