### PR TITLE
Add pkg-config installation to Haskell 9.8 Dockerfile

### DIFF
--- a/dockerfiles/haskell-9.8.Dockerfile
+++ b/dockerfiles/haskell-9.8.Dockerfile
@@ -1,5 +1,12 @@
 FROM haskell:9.8.4-bullseye
 
+# hadolint ignore=DL3008
+RUN apt-get update && \
+    apt-get install --no-install-recommends -y \
+        pkg-config \
+    && apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
 # Ensures the container is re-built if go.mod or go.sum changes
 ENV CODECRAFTERS_DEPENDENCY_FILE_PATHS="stack.yaml,package.yaml,stack.yaml.lock"
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: only updates the Haskell 9.8 Docker image to include an additional build dependency; main impact is slightly longer image build time and potential apt package drift.
> 
> **Overview**
> Updates the `haskell-9.8` Dockerfile to install `pkg-config` via `apt-get` (with cleanup to keep the layer small), ensuring native-dependency Haskell builds can resolve `pkg-config` during `stack build`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5aaf366aa8e7251422a81059e7b41141028b76fb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->