### PR TITLE
https://linear.app/codecrafters/issue/CC-2159/replace-git-commands-in-readmes-as-cc-submit

### DIFF
--- a/compiled_starters/c/README.md
+++ b/compiled_starters/c/README.md
@@ -33,5 +33,5 @@ Note: This section is for stages 2 and beyond.
 1. Ensure you have `cmake` installed locally
 1. Run `./your_program.sh` to run your program, which is implemented in
    `src/main.c`.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.

--- a/compiled_starters/clojure/README.md
+++ b/compiled_starters/clojure/README.md
@@ -34,5 +34,5 @@ Note: This section is for stages 2 and beyond.
 1. Ensure you have `clj` installed locally
 1. Run `./your_program.sh` to run your program, which is implemented in
    `src/http_server/core.clj`.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.

--- a/compiled_starters/cpp/README.md
+++ b/compiled_starters/cpp/README.md
@@ -33,5 +33,5 @@ Note: This section is for stages 2 and beyond.
 1. Ensure you have `cmake` installed locally
 1. Run `./your_program.sh` to run your program, which is implemented in
    `src/main.cpp`.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.

--- a/compiled_starters/csharp/README.md
+++ b/compiled_starters/csharp/README.md
@@ -33,5 +33,5 @@ Note: This section is for stages 2 and beyond.
 1. Ensure you have `dotnet (9.0)` installed locally
 1. Run `./your_program.sh` to run your program, which is implemented in
    `src/Server.cs`.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.

--- a/compiled_starters/dart/README.md
+++ b/compiled_starters/dart/README.md
@@ -33,5 +33,5 @@ Note: This section is for stages 2 and beyond.
 1. Ensure you have `dart (3.4)` installed locally
 1. Run `./your_program.sh` to run your program, which is implemented in
    `bin/main.dart`.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.

--- a/compiled_starters/elixir/README.md
+++ b/compiled_starters/elixir/README.md
@@ -33,5 +33,5 @@ Note: This section is for stages 2 and beyond.
 1. Ensure you have `mix` installed locally
 1. Run `./your_program.sh` to run your program, which is implemented in
    `lib/main.ex`.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.

--- a/compiled_starters/gleam/README.md
+++ b/compiled_starters/gleam/README.md
@@ -34,5 +34,5 @@ Note: This section is for stages 2 and beyond.
 1. Ensure you have `gleam (1.14.0)` installed locally
 1. Run `./your_program.sh` to run your program, which is implemented in
    `src/main.gleam`.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.

--- a/compiled_starters/go/README.md
+++ b/compiled_starters/go/README.md
@@ -33,5 +33,5 @@ Note: This section is for stages 2 and beyond.
 1. Ensure you have `go (1.26)` installed locally
 1. Run `./your_program.sh` to run your program, which is implemented in
    `app/main.go`.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.

--- a/compiled_starters/haskell/README.md
+++ b/compiled_starters/haskell/README.md
@@ -33,5 +33,5 @@ Note: This section is for stages 2 and beyond.
 1. Ensure you have `stack (24.33)` installed locally
 1. Run `./your_program.sh` to run your program, which is implemented in
    `app/Main.hs`.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.

--- a/compiled_starters/java/README.md
+++ b/compiled_starters/java/README.md
@@ -34,5 +34,5 @@ Note: This section is for stages 2 and beyond.
 1. Ensure you have `mvn` installed locally
 1. Run `./your_program.sh` to run your program, which is implemented in
    `src/main/java/Main.java`.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.

--- a/compiled_starters/javascript/README.md
+++ b/compiled_starters/javascript/README.md
@@ -33,5 +33,5 @@ Note: This section is for stages 2 and beyond.
 1. Ensure you have `node (25)` installed locally
 1. Run `./your_program.sh` to run your program, which is implemented in
    `app/main.js`.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.

--- a/compiled_starters/kotlin/README.md
+++ b/compiled_starters/kotlin/README.md
@@ -34,5 +34,5 @@ Note: This section is for stages 2 and beyond.
 1. Ensure you have `gradle (9.4.1)` installed locally
 1. Run `./your_program.sh` to run your program, which is implemented in
    `app/src/main/kotlin/App.kt`.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.

--- a/compiled_starters/ocaml/README.md
+++ b/compiled_starters/ocaml/README.md
@@ -33,5 +33,5 @@ Note: This section is for stages 2 and beyond.
 1. Ensure you have `dune` installed locally
 1. Run `./your_program.sh` to run your program, which is implemented in
    `src/main.ml`.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.

--- a/compiled_starters/odin/README.md
+++ b/compiled_starters/odin/README.md
@@ -33,5 +33,5 @@ Note: This section is for stages 2 and beyond.
 1. Ensure you have `odin (dev-2026-04)` installed locally
 1. Run `./your_program.sh` to run your program, which is implemented in
    `src/main.odin`.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.

--- a/compiled_starters/php/README.md
+++ b/compiled_starters/php/README.md
@@ -33,5 +33,5 @@ Note: This section is for stages 2 and beyond.
 1. Ensure you have `php (8.5)` installed locally
 1. Run `./your_program.sh` to run your program, which is implemented in
    `app/main.php`.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.

--- a/compiled_starters/python/README.md
+++ b/compiled_starters/python/README.md
@@ -33,5 +33,5 @@ Note: This section is for stages 2 and beyond.
 1. Ensure you have `uv` installed locally
 1. Run `./your_program.sh` to run your program, which is implemented in
    `app/main.py`.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.

--- a/compiled_starters/ruby/README.md
+++ b/compiled_starters/ruby/README.md
@@ -33,5 +33,5 @@ Note: This section is for stages 2 and beyond.
 1. Ensure you have `ruby (4.0)` installed locally
 1. Run `./your_program.sh` to run your program, which is implemented in
    `app/main.rb`.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.

--- a/compiled_starters/rust/README.md
+++ b/compiled_starters/rust/README.md
@@ -34,5 +34,5 @@ Note: This section is for stages 2 and beyond.
 1. Run `./your_program.sh` to run your program, which is implemented in
    `src/main.rs`. This command compiles your Rust project, so it might be slow
    the first time you run it. Subsequent runs will be fast.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.

--- a/compiled_starters/scala/README.md
+++ b/compiled_starters/scala/README.md
@@ -34,5 +34,5 @@ Note: This section is for stages 2 and beyond.
 1. Ensure you have `scala-cli` installed locally
 1. Run `./your_program.sh` to run your program, which is implemented in
    `src/main/scala/codecrafters_http_server/App.scala`.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.

--- a/compiled_starters/typescript/README.md
+++ b/compiled_starters/typescript/README.md
@@ -33,5 +33,5 @@ Note: This section is for stages 2 and beyond.
 1. Ensure you have `bun (1.3)` installed locally
 1. Run `./your_program.sh` to run your program, which is implemented in
    `app/main.ts`.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.

--- a/compiled_starters/zig/README.md
+++ b/compiled_starters/zig/README.md
@@ -33,5 +33,5 @@ Note: This section is for stages 2 and beyond.
 1. Ensure you have `zig (0.16)` installed locally
 1. Run `./your_program.sh` to run your program, which is implemented in
    `src/main.zig`.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.

--- a/solutions/c/01-at4/code/README.md
+++ b/solutions/c/01-at4/code/README.md
@@ -33,5 +33,5 @@ Note: This section is for stages 2 and beyond.
 1. Ensure you have `cmake` installed locally
 1. Run `./your_program.sh` to run your program, which is implemented in
    `src/main.c`.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.

--- a/solutions/clojure/01-at4/code/README.md
+++ b/solutions/clojure/01-at4/code/README.md
@@ -34,5 +34,5 @@ Note: This section is for stages 2 and beyond.
 1. Ensure you have `clj` installed locally
 1. Run `./your_program.sh` to run your program, which is implemented in
    `src/http_server/core.clj`.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.

--- a/solutions/cpp/01-at4/code/README.md
+++ b/solutions/cpp/01-at4/code/README.md
@@ -33,5 +33,5 @@ Note: This section is for stages 2 and beyond.
 1. Ensure you have `cmake` installed locally
 1. Run `./your_program.sh` to run your program, which is implemented in
    `src/main.cpp`.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.

--- a/solutions/csharp/01-at4/code/README.md
+++ b/solutions/csharp/01-at4/code/README.md
@@ -33,5 +33,5 @@ Note: This section is for stages 2 and beyond.
 1. Ensure you have `dotnet (9.0)` installed locally
 1. Run `./your_program.sh` to run your program, which is implemented in
    `src/Server.cs`.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.

--- a/solutions/dart/01-at4/code/README.md
+++ b/solutions/dart/01-at4/code/README.md
@@ -33,5 +33,5 @@ Note: This section is for stages 2 and beyond.
 1. Ensure you have `dart (3.4)` installed locally
 1. Run `./your_program.sh` to run your program, which is implemented in
    `bin/main.dart`.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.

--- a/solutions/elixir/01-at4/code/README.md
+++ b/solutions/elixir/01-at4/code/README.md
@@ -33,5 +33,5 @@ Note: This section is for stages 2 and beyond.
 1. Ensure you have `mix` installed locally
 1. Run `./your_program.sh` to run your program, which is implemented in
    `lib/main.ex`.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.

--- a/solutions/gleam/01-at4/code/README.md
+++ b/solutions/gleam/01-at4/code/README.md
@@ -34,5 +34,5 @@ Note: This section is for stages 2 and beyond.
 1. Ensure you have `gleam (1.14.0)` installed locally
 1. Run `./your_program.sh` to run your program, which is implemented in
    `src/main.gleam`.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.

--- a/solutions/go/01-at4/code/README.md
+++ b/solutions/go/01-at4/code/README.md
@@ -33,5 +33,5 @@ Note: This section is for stages 2 and beyond.
 1. Ensure you have `go (1.26)` installed locally
 1. Run `./your_program.sh` to run your program, which is implemented in
    `app/main.go`.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.

--- a/solutions/haskell/01-at4/code/README.md
+++ b/solutions/haskell/01-at4/code/README.md
@@ -33,5 +33,5 @@ Note: This section is for stages 2 and beyond.
 1. Ensure you have `stack (24.33)` installed locally
 1. Run `./your_program.sh` to run your program, which is implemented in
    `app/Main.hs`.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.

--- a/solutions/java/01-at4/code/README.md
+++ b/solutions/java/01-at4/code/README.md
@@ -34,5 +34,5 @@ Note: This section is for stages 2 and beyond.
 1. Ensure you have `mvn` installed locally
 1. Run `./your_program.sh` to run your program, which is implemented in
    `src/main/java/Main.java`.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.

--- a/solutions/javascript/01-at4/code/README.md
+++ b/solutions/javascript/01-at4/code/README.md
@@ -33,5 +33,5 @@ Note: This section is for stages 2 and beyond.
 1. Ensure you have `node (25)` installed locally
 1. Run `./your_program.sh` to run your program, which is implemented in
    `app/main.js`.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.

--- a/solutions/kotlin/01-at4/code/README.md
+++ b/solutions/kotlin/01-at4/code/README.md
@@ -34,5 +34,5 @@ Note: This section is for stages 2 and beyond.
 1. Ensure you have `gradle (9.4.1)` installed locally
 1. Run `./your_program.sh` to run your program, which is implemented in
    `app/src/main/kotlin/App.kt`.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.

--- a/solutions/ocaml/01-at4/code/README.md
+++ b/solutions/ocaml/01-at4/code/README.md
@@ -33,5 +33,5 @@ Note: This section is for stages 2 and beyond.
 1. Ensure you have `dune` installed locally
 1. Run `./your_program.sh` to run your program, which is implemented in
    `src/main.ml`.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.

--- a/solutions/odin/01-at4/code/README.md
+++ b/solutions/odin/01-at4/code/README.md
@@ -33,5 +33,5 @@ Note: This section is for stages 2 and beyond.
 1. Ensure you have `odin (dev-2026-04)` installed locally
 1. Run `./your_program.sh` to run your program, which is implemented in
    `src/main.odin`.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.

--- a/solutions/php/01-at4/code/README.md
+++ b/solutions/php/01-at4/code/README.md
@@ -33,5 +33,5 @@ Note: This section is for stages 2 and beyond.
 1. Ensure you have `php (8.5)` installed locally
 1. Run `./your_program.sh` to run your program, which is implemented in
    `app/main.php`.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.

--- a/solutions/python/01-at4/code/README.md
+++ b/solutions/python/01-at4/code/README.md
@@ -33,5 +33,5 @@ Note: This section is for stages 2 and beyond.
 1. Ensure you have `uv` installed locally
 1. Run `./your_program.sh` to run your program, which is implemented in
    `app/main.py`.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.

--- a/solutions/ruby/01-at4/code/README.md
+++ b/solutions/ruby/01-at4/code/README.md
@@ -33,5 +33,5 @@ Note: This section is for stages 2 and beyond.
 1. Ensure you have `ruby (4.0)` installed locally
 1. Run `./your_program.sh` to run your program, which is implemented in
    `app/main.rb`.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.

--- a/solutions/rust/01-at4/code/README.md
+++ b/solutions/rust/01-at4/code/README.md
@@ -34,5 +34,5 @@ Note: This section is for stages 2 and beyond.
 1. Run `./your_program.sh` to run your program, which is implemented in
    `src/main.rs`. This command compiles your Rust project, so it might be slow
    the first time you run it. Subsequent runs will be fast.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.

--- a/solutions/scala/01-at4/code/README.md
+++ b/solutions/scala/01-at4/code/README.md
@@ -34,5 +34,5 @@ Note: This section is for stages 2 and beyond.
 1. Ensure you have `scala-cli` installed locally
 1. Run `./your_program.sh` to run your program, which is implemented in
    `src/main/scala/codecrafters_http_server/App.scala`.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.

--- a/solutions/typescript/01-at4/code/README.md
+++ b/solutions/typescript/01-at4/code/README.md
@@ -33,5 +33,5 @@ Note: This section is for stages 2 and beyond.
 1. Ensure you have `bun (1.3)` installed locally
 1. Run `./your_program.sh` to run your program, which is implemented in
    `app/main.ts`.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.

--- a/solutions/zig/01-at4/code/README.md
+++ b/solutions/zig/01-at4/code/README.md
@@ -33,5 +33,5 @@ Note: This section is for stages 2 and beyond.
 1. Ensure you have `zig (0.16)` installed locally
 1. Run `./your_program.sh` to run your program, which is implemented in
    `src/main.zig`.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.

--- a/starter_templates/all/code/README.md
+++ b/starter_templates/all/code/README.md
@@ -30,5 +30,4 @@ Note: This section is for stages 2 and beyond.
    `{{ user_editable_file }}`.{{# language_is_rust }} This command compiles your
    Rust project, so it might be slow the first time you run it. Subsequent runs
    will be fast.{{/ language_is_rust}}
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test output will be streamed to your terminal.


### PR DESCRIPTION
https://linear.app/codecrafters/issue/CC-2159/replace-git-commands-in-readmes-as-cc-submit

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes across starter and solution READMEs; low risk aside from potentially confusing instructions if the CLI command differs from user expectations.
> 
> **Overview**
> Updates the Stage 2+ README instructions across all compiled starter repos, corresponding solution repos, and `starter_templates/all/code/README.md` to replace the "commit + `git push origin master`" submission step with `codecrafters submit` (with the same note about streaming test output).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a952d20dcf44de581384e0ee21f1f5718d630355. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->