### PR TITLE
https://linear.app/codecrafters/issue/CC-2159/replace-git-commands-in-readmes-as-cc-submit

### DIFF
--- a/compiled_starters/c/README.md
+++ b/compiled_starters/c/README.md
@@ -17,11 +17,11 @@ and more.
 # Passing the first stage
 
 The entry point for your HTTP server implementation is in `src/main.c`. Study
-and uncomment the relevant code, and push your changes to pass the first stage:
+and uncomment the relevant code, and then run the command below to execute the
+tests on our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 Time to move on to the next stage!

--- a/compiled_starters/clojure/README.md
+++ b/compiled_starters/clojure/README.md
@@ -17,12 +17,11 @@ and more.
 # Passing the first stage
 
 The entry point for your HTTP server implementation is in
-`src/http_server/core.clj`. Study and uncomment the relevant code, and push your
-changes to pass the first stage:
+`src/http_server/core.clj`. Study and uncomment the relevant code, and then run
+the command below to execute the tests on our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 Time to move on to the next stage!

--- a/compiled_starters/cpp/README.md
+++ b/compiled_starters/cpp/README.md
@@ -17,11 +17,11 @@ and more.
 # Passing the first stage
 
 The entry point for your HTTP server implementation is in `src/main.cpp`. Study
-and uncomment the relevant code, and push your changes to pass the first stage:
+and uncomment the relevant code, and then run the command below to execute the
+tests on our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 Time to move on to the next stage!

--- a/compiled_starters/csharp/README.md
+++ b/compiled_starters/csharp/README.md
@@ -17,11 +17,11 @@ and more.
 # Passing the first stage
 
 The entry point for your HTTP server implementation is in `src/Server.cs`. Study
-and uncomment the relevant code, and push your changes to pass the first stage:
+and uncomment the relevant code, and then run the command below to execute the
+tests on our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 Time to move on to the next stage!

--- a/compiled_starters/dart/README.md
+++ b/compiled_starters/dart/README.md
@@ -17,11 +17,11 @@ and more.
 # Passing the first stage
 
 The entry point for your HTTP server implementation is in `bin/main.dart`. Study
-and uncomment the relevant code, and push your changes to pass the first stage:
+and uncomment the relevant code, and then run the command below to execute the
+tests on our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 Time to move on to the next stage!

--- a/compiled_starters/elixir/README.md
+++ b/compiled_starters/elixir/README.md
@@ -17,11 +17,11 @@ and more.
 # Passing the first stage
 
 The entry point for your HTTP server implementation is in `lib/main.ex`. Study
-and uncomment the relevant code, and push your changes to pass the first stage:
+and uncomment the relevant code, and then run the command below to execute the
+tests on our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 Time to move on to the next stage!

--- a/compiled_starters/gleam/README.md
+++ b/compiled_starters/gleam/README.md
@@ -17,12 +17,11 @@ and more.
 # Passing the first stage
 
 The entry point for your HTTP server implementation is in `src/main.gleam`.
-Study and uncomment the relevant code, and push your changes to pass the first
-stage:
+Study and uncomment the relevant code, and then run the command below to execute
+the tests on our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 Time to move on to the next stage!

--- a/compiled_starters/go/README.md
+++ b/compiled_starters/go/README.md
@@ -17,11 +17,11 @@ and more.
 # Passing the first stage
 
 The entry point for your HTTP server implementation is in `app/main.go`. Study
-and uncomment the relevant code, and push your changes to pass the first stage:
+and uncomment the relevant code, and then run the command below to execute the
+tests on our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 Time to move on to the next stage!

--- a/compiled_starters/haskell/README.md
+++ b/compiled_starters/haskell/README.md
@@ -17,11 +17,11 @@ and more.
 # Passing the first stage
 
 The entry point for your HTTP server implementation is in `app/Main.hs`. Study
-and uncomment the relevant code, and push your changes to pass the first stage:
+and uncomment the relevant code, and then run the command below to execute the
+tests on our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 Time to move on to the next stage!

--- a/compiled_starters/java/README.md
+++ b/compiled_starters/java/README.md
@@ -17,12 +17,11 @@ and more.
 # Passing the first stage
 
 The entry point for your HTTP server implementation is in
-`src/main/java/Main.java`. Study and uncomment the relevant code, and push your
-changes to pass the first stage:
+`src/main/java/Main.java`. Study and uncomment the relevant code, and then run
+the command below to execute the tests on our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 Time to move on to the next stage!

--- a/compiled_starters/javascript/README.md
+++ b/compiled_starters/javascript/README.md
@@ -17,11 +17,11 @@ and more.
 # Passing the first stage
 
 The entry point for your HTTP server implementation is in `app/main.js`. Study
-and uncomment the relevant code, and push your changes to pass the first stage:
+and uncomment the relevant code, and then run the command below to execute the
+tests on our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 Time to move on to the next stage!

--- a/compiled_starters/kotlin/README.md
+++ b/compiled_starters/kotlin/README.md
@@ -17,12 +17,11 @@ and more.
 # Passing the first stage
 
 The entry point for your HTTP server implementation is in
-`app/src/main/kotlin/App.kt`. Study and uncomment the relevant code, and push
-your changes to pass the first stage:
+`app/src/main/kotlin/App.kt`. Study and uncomment the relevant code, and then
+run the command below to execute the tests on our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 Time to move on to the next stage!

--- a/compiled_starters/ocaml/README.md
+++ b/compiled_starters/ocaml/README.md
@@ -17,11 +17,11 @@ and more.
 # Passing the first stage
 
 The entry point for your HTTP server implementation is in `src/main.ml`. Study
-and uncomment the relevant code, and push your changes to pass the first stage:
+and uncomment the relevant code, and then run the command below to execute the
+tests on our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 Time to move on to the next stage!

--- a/compiled_starters/odin/README.md
+++ b/compiled_starters/odin/README.md
@@ -17,11 +17,11 @@ and more.
 # Passing the first stage
 
 The entry point for your HTTP server implementation is in `src/main.odin`. Study
-and uncomment the relevant code, and push your changes to pass the first stage:
+and uncomment the relevant code, and then run the command below to execute the
+tests on our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 Time to move on to the next stage!

--- a/compiled_starters/php/README.md
+++ b/compiled_starters/php/README.md
@@ -17,11 +17,11 @@ and more.
 # Passing the first stage
 
 The entry point for your HTTP server implementation is in `app/main.php`. Study
-and uncomment the relevant code, and push your changes to pass the first stage:
+and uncomment the relevant code, and then run the command below to execute the
+tests on our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 Time to move on to the next stage!

--- a/compiled_starters/python/README.md
+++ b/compiled_starters/python/README.md
@@ -17,11 +17,11 @@ and more.
 # Passing the first stage
 
 The entry point for your HTTP server implementation is in `app/main.py`. Study
-and uncomment the relevant code, and push your changes to pass the first stage:
+and uncomment the relevant code, and then run the command below to execute the
+tests on our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 Time to move on to the next stage!

--- a/compiled_starters/ruby/README.md
+++ b/compiled_starters/ruby/README.md
@@ -17,11 +17,11 @@ and more.
 # Passing the first stage
 
 The entry point for your HTTP server implementation is in `app/main.rb`. Study
-and uncomment the relevant code, and push your changes to pass the first stage:
+and uncomment the relevant code, and then run the command below to execute the
+tests on our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 Time to move on to the next stage!

--- a/compiled_starters/rust/README.md
+++ b/compiled_starters/rust/README.md
@@ -17,11 +17,11 @@ and more.
 # Passing the first stage
 
 The entry point for your HTTP server implementation is in `src/main.rs`. Study
-and uncomment the relevant code, and push your changes to pass the first stage:
+and uncomment the relevant code, and then run the command below to execute the
+tests on our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 Time to move on to the next stage!

--- a/compiled_starters/scala/README.md
+++ b/compiled_starters/scala/README.md
@@ -18,11 +18,11 @@ and more.
 
 The entry point for your HTTP server implementation is in
 `src/main/scala/codecrafters_http_server/App.scala`. Study and uncomment the
-relevant code, and push your changes to pass the first stage:
+relevant code, and then run the command below to execute the tests on our
+servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 Time to move on to the next stage!

--- a/compiled_starters/typescript/README.md
+++ b/compiled_starters/typescript/README.md
@@ -17,11 +17,11 @@ and more.
 # Passing the first stage
 
 The entry point for your HTTP server implementation is in `app/main.ts`. Study
-and uncomment the relevant code, and push your changes to pass the first stage:
+and uncomment the relevant code, and then run the command below to execute the
+tests on our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 Time to move on to the next stage!

--- a/compiled_starters/zig/README.md
+++ b/compiled_starters/zig/README.md
@@ -17,11 +17,11 @@ and more.
 # Passing the first stage
 
 The entry point for your HTTP server implementation is in `src/main.zig`. Study
-and uncomment the relevant code, and push your changes to pass the first stage:
+and uncomment the relevant code, and then run the command below to execute the
+tests on our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 Time to move on to the next stage!

--- a/solutions/c/01-at4/code/README.md
+++ b/solutions/c/01-at4/code/README.md
@@ -17,11 +17,11 @@ and more.
 # Passing the first stage
 
 The entry point for your HTTP server implementation is in `src/main.c`. Study
-and uncomment the relevant code, and push your changes to pass the first stage:
+and uncomment the relevant code, and then run the command below to execute the
+tests on our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 Time to move on to the next stage!

--- a/solutions/clojure/01-at4/code/README.md
+++ b/solutions/clojure/01-at4/code/README.md
@@ -17,12 +17,11 @@ and more.
 # Passing the first stage
 
 The entry point for your HTTP server implementation is in
-`src/http_server/core.clj`. Study and uncomment the relevant code, and push your
-changes to pass the first stage:
+`src/http_server/core.clj`. Study and uncomment the relevant code, and then run
+the command below to execute the tests on our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 Time to move on to the next stage!

--- a/solutions/cpp/01-at4/code/README.md
+++ b/solutions/cpp/01-at4/code/README.md
@@ -17,11 +17,11 @@ and more.
 # Passing the first stage
 
 The entry point for your HTTP server implementation is in `src/main.cpp`. Study
-and uncomment the relevant code, and push your changes to pass the first stage:
+and uncomment the relevant code, and then run the command below to execute the
+tests on our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 Time to move on to the next stage!

--- a/solutions/csharp/01-at4/code/README.md
+++ b/solutions/csharp/01-at4/code/README.md
@@ -17,11 +17,11 @@ and more.
 # Passing the first stage
 
 The entry point for your HTTP server implementation is in `src/Server.cs`. Study
-and uncomment the relevant code, and push your changes to pass the first stage:
+and uncomment the relevant code, and then run the command below to execute the
+tests on our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 Time to move on to the next stage!

--- a/solutions/dart/01-at4/code/README.md
+++ b/solutions/dart/01-at4/code/README.md
@@ -17,11 +17,11 @@ and more.
 # Passing the first stage
 
 The entry point for your HTTP server implementation is in `bin/main.dart`. Study
-and uncomment the relevant code, and push your changes to pass the first stage:
+and uncomment the relevant code, and then run the command below to execute the
+tests on our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 Time to move on to the next stage!

--- a/solutions/elixir/01-at4/code/README.md
+++ b/solutions/elixir/01-at4/code/README.md
@@ -17,11 +17,11 @@ and more.
 # Passing the first stage
 
 The entry point for your HTTP server implementation is in `lib/main.ex`. Study
-and uncomment the relevant code, and push your changes to pass the first stage:
+and uncomment the relevant code, and then run the command below to execute the
+tests on our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 Time to move on to the next stage!

--- a/solutions/gleam/01-at4/code/README.md
+++ b/solutions/gleam/01-at4/code/README.md
@@ -17,12 +17,11 @@ and more.
 # Passing the first stage
 
 The entry point for your HTTP server implementation is in `src/main.gleam`.
-Study and uncomment the relevant code, and push your changes to pass the first
-stage:
+Study and uncomment the relevant code, and then run the command below to execute
+the tests on our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 Time to move on to the next stage!

--- a/solutions/go/01-at4/code/README.md
+++ b/solutions/go/01-at4/code/README.md
@@ -17,11 +17,11 @@ and more.
 # Passing the first stage
 
 The entry point for your HTTP server implementation is in `app/main.go`. Study
-and uncomment the relevant code, and push your changes to pass the first stage:
+and uncomment the relevant code, and then run the command below to execute the
+tests on our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 Time to move on to the next stage!

--- a/solutions/haskell/01-at4/code/README.md
+++ b/solutions/haskell/01-at4/code/README.md
@@ -17,11 +17,11 @@ and more.
 # Passing the first stage
 
 The entry point for your HTTP server implementation is in `app/Main.hs`. Study
-and uncomment the relevant code, and push your changes to pass the first stage:
+and uncomment the relevant code, and then run the command below to execute the
+tests on our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 Time to move on to the next stage!

--- a/solutions/java/01-at4/code/README.md
+++ b/solutions/java/01-at4/code/README.md
@@ -17,12 +17,11 @@ and more.
 # Passing the first stage
 
 The entry point for your HTTP server implementation is in
-`src/main/java/Main.java`. Study and uncomment the relevant code, and push your
-changes to pass the first stage:
+`src/main/java/Main.java`. Study and uncomment the relevant code, and then run
+the command below to execute the tests on our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 Time to move on to the next stage!

--- a/solutions/javascript/01-at4/code/README.md
+++ b/solutions/javascript/01-at4/code/README.md
@@ -17,11 +17,11 @@ and more.
 # Passing the first stage
 
 The entry point for your HTTP server implementation is in `app/main.js`. Study
-and uncomment the relevant code, and push your changes to pass the first stage:
+and uncomment the relevant code, and then run the command below to execute the
+tests on our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 Time to move on to the next stage!

--- a/solutions/kotlin/01-at4/code/README.md
+++ b/solutions/kotlin/01-at4/code/README.md
@@ -17,12 +17,11 @@ and more.
 # Passing the first stage
 
 The entry point for your HTTP server implementation is in
-`app/src/main/kotlin/App.kt`. Study and uncomment the relevant code, and push
-your changes to pass the first stage:
+`app/src/main/kotlin/App.kt`. Study and uncomment the relevant code, and then
+run the command below to execute the tests on our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 Time to move on to the next stage!

--- a/solutions/ocaml/01-at4/code/README.md
+++ b/solutions/ocaml/01-at4/code/README.md
@@ -17,11 +17,11 @@ and more.
 # Passing the first stage
 
 The entry point for your HTTP server implementation is in `src/main.ml`. Study
-and uncomment the relevant code, and push your changes to pass the first stage:
+and uncomment the relevant code, and then run the command below to execute the
+tests on our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 Time to move on to the next stage!

--- a/solutions/odin/01-at4/code/README.md
+++ b/solutions/odin/01-at4/code/README.md
@@ -17,11 +17,11 @@ and more.
 # Passing the first stage
 
 The entry point for your HTTP server implementation is in `src/main.odin`. Study
-and uncomment the relevant code, and push your changes to pass the first stage:
+and uncomment the relevant code, and then run the command below to execute the
+tests on our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 Time to move on to the next stage!

--- a/solutions/php/01-at4/code/README.md
+++ b/solutions/php/01-at4/code/README.md
@@ -17,11 +17,11 @@ and more.
 # Passing the first stage
 
 The entry point for your HTTP server implementation is in `app/main.php`. Study
-and uncomment the relevant code, and push your changes to pass the first stage:
+and uncomment the relevant code, and then run the command below to execute the
+tests on our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 Time to move on to the next stage!

--- a/solutions/python/01-at4/code/README.md
+++ b/solutions/python/01-at4/code/README.md
@@ -17,11 +17,11 @@ and more.
 # Passing the first stage
 
 The entry point for your HTTP server implementation is in `app/main.py`. Study
-and uncomment the relevant code, and push your changes to pass the first stage:
+and uncomment the relevant code, and then run the command below to execute the
+tests on our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 Time to move on to the next stage!

--- a/solutions/ruby/01-at4/code/README.md
+++ b/solutions/ruby/01-at4/code/README.md
@@ -17,11 +17,11 @@ and more.
 # Passing the first stage
 
 The entry point for your HTTP server implementation is in `app/main.rb`. Study
-and uncomment the relevant code, and push your changes to pass the first stage:
+and uncomment the relevant code, and then run the command below to execute the
+tests on our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 Time to move on to the next stage!

--- a/solutions/rust/01-at4/code/README.md
+++ b/solutions/rust/01-at4/code/README.md
@@ -17,11 +17,11 @@ and more.
 # Passing the first stage
 
 The entry point for your HTTP server implementation is in `src/main.rs`. Study
-and uncomment the relevant code, and push your changes to pass the first stage:
+and uncomment the relevant code, and then run the command below to execute the
+tests on our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 Time to move on to the next stage!

--- a/solutions/scala/01-at4/code/README.md
+++ b/solutions/scala/01-at4/code/README.md
@@ -18,11 +18,11 @@ and more.
 
 The entry point for your HTTP server implementation is in
 `src/main/scala/codecrafters_http_server/App.scala`. Study and uncomment the
-relevant code, and push your changes to pass the first stage:
+relevant code, and then run the command below to execute the tests on our
+servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 Time to move on to the next stage!

--- a/solutions/typescript/01-at4/code/README.md
+++ b/solutions/typescript/01-at4/code/README.md
@@ -17,11 +17,11 @@ and more.
 # Passing the first stage
 
 The entry point for your HTTP server implementation is in `app/main.ts`. Study
-and uncomment the relevant code, and push your changes to pass the first stage:
+and uncomment the relevant code, and then run the command below to execute the
+tests on our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 Time to move on to the next stage!

--- a/solutions/zig/01-at4/code/README.md
+++ b/solutions/zig/01-at4/code/README.md
@@ -17,11 +17,11 @@ and more.
 # Passing the first stage
 
 The entry point for your HTTP server implementation is in `src/main.zig`. Study
-and uncomment the relevant code, and push your changes to pass the first stage:
+and uncomment the relevant code, and then run the command below to execute the
+tests on our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 Time to move on to the next stage!

--- a/starter_templates/all/code/README.md
+++ b/starter_templates/all/code/README.md
@@ -12,11 +12,10 @@ Along the way you'll learn about TCP servers, [HTTP request syntax](https://www.
 
 # Passing the first stage
 
-The entry point for your HTTP server implementation is in `{{ user_editable_file }}`. Study and uncomment the relevant code, and push your changes to pass the first stage:
+The entry point for your HTTP server implementation is in `{{ user_editable_file }}`. Study and uncomment the relevant code, and then run the command below to execute the tests on our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 Time to move on to the next stage!


### PR DESCRIPTION
https://linear.app/codecrafters/issue/CC-2159/replace-git-commands-in-readmes-as-cc-submit

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that updates onboarding instructions; no runtime or build logic is affected.
> 
> **Overview**
> Updates the “Passing the first stage” instructions across all compiled starters and included solutions to use `codecrafters submit` (run tests on CodeCrafters’ servers) instead of telling users to `git commit`/`git push`.
> 
> Aligns the shared template (`starter_templates/all/code/README.md`) and language-specific READMEs with the new submission workflow wording.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4d723b7480b0da605ce56e843ebc4d3ae5733b8e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->