### PR TITLE
CC-2274: Upgrade Gleam to v0.16

### DIFF
--- a/compiled_starters/gleam/.codecrafters/compile.sh
+++ b/compiled_starters/gleam/.codecrafters/compile.sh
@@ -9,3 +9,4 @@
 set -e # Exit on failure
 
 gleam build
+gleam run -m gleescript

--- a/compiled_starters/gleam/.codecrafters/run.sh
+++ b/compiled_starters/gleam/.codecrafters/run.sh
@@ -8,4 +8,4 @@
 
 set -e # Exit on failure
 
-exec gleam run --no-print-progress --module main -- "$@"
+exec "$(dirname "$0")/main" "$@"

--- a/compiled_starters/gleam/.gitignore
+++ b/compiled_starters/gleam/.gitignore
@@ -2,3 +2,4 @@
 *.ez
 /build
 erl_crash.dump
+main

--- a/compiled_starters/gleam/codecrafters.yml
+++ b/compiled_starters/gleam/codecrafters.yml
@@ -7,5 +7,5 @@ debug: false
 # Use this to change the Gleam version used to run your code
 # on Codecrafters.
 #
-# Available versions: gleam-1.14
-buildpack: gleam-1.14
+# Available versions: gleam-1.16
+buildpack: gleam-1.16

--- a/compiled_starters/gleam/gleam.toml
+++ b/compiled_starters/gleam/gleam.toml
@@ -1,14 +1,15 @@
-name = "codecrafters_http_server"
+name = "main"
 version = "1.0.0"
 
 # For a full reference of all the available options, you can have a look at
 # https://gleam.run/writing-gleam/gleam-toml/.
 
 [dependencies]
-gleam_stdlib = "~> 0.34 or ~> 1.0"
-gleam_erlang = "~> 0.25"
-gleam_otp = "~> 0.10"
-glisten = "~> 2.0"
+gleam_stdlib = "~> 1.0"
+gleam_erlang = "~> 1.0"
+gleam_otp = "~> 1.0"
+glisten = "~> 9.0"
 
 [dev-dependencies]
+gleescript = ">= 1.4.0 and < 2.0.0"
 gleeunit = "~> 1.0"

--- a/compiled_starters/gleam/manifest.toml
+++ b/compiled_starters/gleam/manifest.toml
@@ -2,16 +2,25 @@
 # You typically do not need to edit this file
 
 packages = [
-  { name = "gleam_erlang", version = "0.25.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_erlang", source = "hex", outer_checksum = "054D571A7092D2A9727B3E5D183B7507DAB0DA41556EC9133606F09C15497373" },
-  { name = "gleam_otp", version = "0.10.0", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_stdlib"], otp_app = "gleam_otp", source = "hex", outer_checksum = "0B04FE915ACECE539B317F9652CAADBBC0F000184D586AAAF2D94C100945D72B" },
-  { name = "gleam_stdlib", version = "0.39.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "2D7DE885A6EA7F1D5015D1698920C9BAF7241102836CE0C3837A4F160128A9C4" },
-  { name = "gleeunit", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "F7A7228925D3EE7D0813C922E062BFD6D7E9310F0BEE585D3A42F3307E3CFD13" },
-  { name = "glisten", version = "2.0.0", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_otp", "gleam_stdlib"], otp_app = "glisten", source = "hex", outer_checksum = "CF3A9383E9BA4A8CBAF2F7B799716290D02F2AC34E7A77556B49376B662B9314" },
+  { name = "argv", version = "1.1.0", build_tools = ["gleam"], requirements = [], otp_app = "argv", source = "hex", outer_checksum = "3277D100448BDB4A29B6D58C0F36F631CBC349E8BDD09766C6309DF202831140" },
+  { name = "filepath", version = "1.1.2", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "filepath", source = "hex", outer_checksum = "B06A9AF0BF10E51401D64B98E4B627F1D2E48C154967DA7AF4D0914780A6D40A" },
+  { name = "gleam_erlang", version = "1.3.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_erlang", source = "hex", outer_checksum = "1124AD3AA21143E5AF0FC5CF3D9529F6DB8CA03E43A55711B60B6B7B3874375C" },
+  { name = "gleam_otp", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_stdlib"], otp_app = "gleam_otp", source = "hex", outer_checksum = "BA6A294E295E428EC1562DC1C11EA7530DCB981E8359134BEABC8493B7B2258E" },
+  { name = "gleam_stdlib", version = "1.0.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "960090C2FB391784BB34267B099DC9315CC1B1F6013E7415BC763CEF1905D7D3" },
+  { name = "gleam_time", version = "1.8.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_time", source = "hex", outer_checksum = "533D8723774D61AD4998324F5DD1DABDCDBFABAFB9E87CB5D03C6955448FC97D" },
+  { name = "gleescript", version = "1.5.2", build_tools = ["gleam"], requirements = ["argv", "filepath", "gleam_erlang", "gleam_stdlib", "simplifile", "snag", "tom"], otp_app = "gleescript", source = "hex", outer_checksum = "27AC58481742ED29D9B37C506F78958A8AD798750A79ED08C8F8AFBA8F23563B" },
+  { name = "gleeunit", version = "1.10.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "254B697FE72EEAD7BF82E941723918E421317813AC49923EE76A18C788C61E72" },
+  { name = "glisten", version = "9.0.1", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_otp", "gleam_stdlib", "logging"], otp_app = "glisten", source = "hex", outer_checksum = "7795AA50830656F3A0316A6B26595F893C83272DA901B3405E31339CAA31A10B" },
+  { name = "logging", version = "1.5.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "logging", source = "hex", outer_checksum = "BC5F18CE5DD9686100229FE5409BDC3DD5C46D5A7DF2F804AD2D8F0DD6C5060E" },
+  { name = "simplifile", version = "2.4.0", build_tools = ["gleam"], requirements = ["filepath", "gleam_stdlib"], otp_app = "simplifile", source = "hex", outer_checksum = "7C18AFA4FED0B4CE1FA5B0B4BAC1FA1744427054EA993565F6F3F82E5453170D" },
+  { name = "snag", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "snag", source = "hex", outer_checksum = "274F41D6C3ECF99F7686FDCE54183333E41D2C1CA5A3A673F9A8B2C7A4401077" },
+  { name = "tom", version = "2.1.0", build_tools = ["gleam"], requirements = ["gleam_stdlib", "gleam_time"], otp_app = "tom", source = "hex", outer_checksum = "DCF04CB7AB35D58CFC598C66EA2E1816D160759802C89B2BA6238780D59BC256" },
 ]
 
 [requirements]
-gleam_erlang = { version = "~> 0.25" }
-gleam_otp = { version = "~> 0.10" }
-gleam_stdlib = { version = "~> 0.34 or ~> 1.0" }
+gleam_erlang = { version = "~> 1.0" }
+gleam_otp = { version = "~> 1.0" }
+gleam_stdlib = { version = "~> 1.0" }
+gleescript = { version = ">= 1.4.0 and < 2.0.0" }
 gleeunit = { version = "~> 1.0" }
-glisten = { version = "~> 2.0" }
+glisten = { version = "~> 9.0" }

--- a/compiled_starters/gleam/src/main.gleam
+++ b/compiled_starters/gleam/src/main.gleam
@@ -2,15 +2,14 @@ import gleam/io
 
 import gleam/erlang/process
 import gleam/option.{None}
-import gleam/otp/actor
 import glisten
 
 pub fn main() {
   // Ensures gleam doesn't complain about unused imports in stage 1 (feel free to remove this!)
-  let _ = glisten.handler
-  let _ = glisten.serve
+  let _ = glisten.new
+  let _ = glisten.start
+  let _ = glisten.continue
   let _ = process.sleep_forever
-  let _ = actor.continue
   let _ = None
 
   // You can use print statements as follows for debugging, they'll be visible when running tests.
@@ -19,11 +18,11 @@ pub fn main() {
   // TODO: Uncomment the code below to pass the first stage
   //
   // let assert Ok(_) =
-  //   glisten.handler(fn(_conn) { #(Nil, None) }, fn(_msg, state, _conn) {
+  //   glisten.new(fn(_conn) { #(Nil, None) }, fn(state, _msg, _conn) {
   //     io.println("Received message!")
-  //     actor.continue(state)
+  //     glisten.continue(state)
   //   })
-  //   |> glisten.serve(4221)
+  //   |> glisten.start(4221)
   //
   // process.sleep_forever()
 }

--- a/compiled_starters/gleam/your_program.sh
+++ b/compiled_starters/gleam/your_program.sh
@@ -15,10 +15,11 @@ set -e # Exit early if any commands fail
 (
   cd "$(dirname "$0")" # Ensure compile steps are run within the repository directory
   gleam build
+  gleam run -m gleescript
 )
 
 # Copied from .codecrafters/run.sh
 #
 # - Edit this to change how your program runs locally
 # - Edit .codecrafters/run.sh to change how your program runs remotely
-exec gleam run --no-print-progress --module main -- "$@"
+exec "$(dirname "$0")/main" "$@"

--- a/dockerfiles/gleam-1.16.Dockerfile
+++ b/dockerfiles/gleam-1.16.Dockerfile
@@ -1,0 +1,20 @@
+# syntax=docker/dockerfile:1.7-labs
+FROM ghcr.io/gleam-lang/gleam:v1.16.0-erlang-alpine
+
+# Rebuild if gleam.toml or manifest.toml change
+ENV CODECRAFTERS_DEPENDENCY_FILE_PATHS="gleam.toml,manifest.toml"
+
+RUN apk add --no-cache \
+    build-base~=0.5
+
+WORKDIR /app
+
+# .git & README.md are unique per-repository. We ignore them on first copy to prevent cache misses
+COPY --exclude=.git --exclude=README.md . /app
+
+# Force deps to be downloaded
+RUN gleam build
+
+# Cache build directory
+RUN mkdir -p /app-cached
+RUN mv build /app-cached/build

--- a/solutions/gleam/01-at4/code/.codecrafters/compile.sh
+++ b/solutions/gleam/01-at4/code/.codecrafters/compile.sh
@@ -9,3 +9,4 @@
 set -e # Exit on failure
 
 gleam build
+gleam run -m gleescript

--- a/solutions/gleam/01-at4/code/.codecrafters/run.sh
+++ b/solutions/gleam/01-at4/code/.codecrafters/run.sh
@@ -8,4 +8,4 @@
 
 set -e # Exit on failure
 
-exec gleam run --no-print-progress --module main -- "$@"
+exec "$(dirname "$0")/main" "$@"

--- a/solutions/gleam/01-at4/code/.gitignore
+++ b/solutions/gleam/01-at4/code/.gitignore
@@ -2,3 +2,4 @@
 *.ez
 /build
 erl_crash.dump
+main

--- a/solutions/gleam/01-at4/code/codecrafters.yml
+++ b/solutions/gleam/01-at4/code/codecrafters.yml
@@ -7,5 +7,5 @@ debug: false
 # Use this to change the Gleam version used to run your code
 # on Codecrafters.
 #
-# Available versions: gleam-1.14
-buildpack: gleam-1.14
+# Available versions: gleam-1.16
+buildpack: gleam-1.16

--- a/solutions/gleam/01-at4/code/gleam.toml
+++ b/solutions/gleam/01-at4/code/gleam.toml
@@ -1,14 +1,15 @@
-name = "codecrafters_http_server"
+name = "main"
 version = "1.0.0"
 
 # For a full reference of all the available options, you can have a look at
 # https://gleam.run/writing-gleam/gleam-toml/.
 
 [dependencies]
-gleam_stdlib = "~> 0.34 or ~> 1.0"
-gleam_erlang = "~> 0.25"
-gleam_otp = "~> 0.10"
-glisten = "~> 2.0"
+gleam_stdlib = "~> 1.0"
+gleam_erlang = "~> 1.0"
+gleam_otp = "~> 1.0"
+glisten = "~> 9.0"
 
 [dev-dependencies]
+gleescript = ">= 1.4.0 and < 2.0.0"
 gleeunit = "~> 1.0"

--- a/solutions/gleam/01-at4/code/manifest.toml
+++ b/solutions/gleam/01-at4/code/manifest.toml
@@ -2,16 +2,25 @@
 # You typically do not need to edit this file
 
 packages = [
-  { name = "gleam_erlang", version = "0.25.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_erlang", source = "hex", outer_checksum = "054D571A7092D2A9727B3E5D183B7507DAB0DA41556EC9133606F09C15497373" },
-  { name = "gleam_otp", version = "0.10.0", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_stdlib"], otp_app = "gleam_otp", source = "hex", outer_checksum = "0B04FE915ACECE539B317F9652CAADBBC0F000184D586AAAF2D94C100945D72B" },
-  { name = "gleam_stdlib", version = "0.39.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "2D7DE885A6EA7F1D5015D1698920C9BAF7241102836CE0C3837A4F160128A9C4" },
-  { name = "gleeunit", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "F7A7228925D3EE7D0813C922E062BFD6D7E9310F0BEE585D3A42F3307E3CFD13" },
-  { name = "glisten", version = "2.0.0", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_otp", "gleam_stdlib"], otp_app = "glisten", source = "hex", outer_checksum = "CF3A9383E9BA4A8CBAF2F7B799716290D02F2AC34E7A77556B49376B662B9314" },
+  { name = "argv", version = "1.1.0", build_tools = ["gleam"], requirements = [], otp_app = "argv", source = "hex", outer_checksum = "3277D100448BDB4A29B6D58C0F36F631CBC349E8BDD09766C6309DF202831140" },
+  { name = "filepath", version = "1.1.2", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "filepath", source = "hex", outer_checksum = "B06A9AF0BF10E51401D64B98E4B627F1D2E48C154967DA7AF4D0914780A6D40A" },
+  { name = "gleam_erlang", version = "1.3.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_erlang", source = "hex", outer_checksum = "1124AD3AA21143E5AF0FC5CF3D9529F6DB8CA03E43A55711B60B6B7B3874375C" },
+  { name = "gleam_otp", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_stdlib"], otp_app = "gleam_otp", source = "hex", outer_checksum = "BA6A294E295E428EC1562DC1C11EA7530DCB981E8359134BEABC8493B7B2258E" },
+  { name = "gleam_stdlib", version = "1.0.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "960090C2FB391784BB34267B099DC9315CC1B1F6013E7415BC763CEF1905D7D3" },
+  { name = "gleam_time", version = "1.8.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_time", source = "hex", outer_checksum = "533D8723774D61AD4998324F5DD1DABDCDBFABAFB9E87CB5D03C6955448FC97D" },
+  { name = "gleescript", version = "1.5.2", build_tools = ["gleam"], requirements = ["argv", "filepath", "gleam_erlang", "gleam_stdlib", "simplifile", "snag", "tom"], otp_app = "gleescript", source = "hex", outer_checksum = "27AC58481742ED29D9B37C506F78958A8AD798750A79ED08C8F8AFBA8F23563B" },
+  { name = "gleeunit", version = "1.10.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "254B697FE72EEAD7BF82E941723918E421317813AC49923EE76A18C788C61E72" },
+  { name = "glisten", version = "9.0.1", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_otp", "gleam_stdlib", "logging"], otp_app = "glisten", source = "hex", outer_checksum = "7795AA50830656F3A0316A6B26595F893C83272DA901B3405E31339CAA31A10B" },
+  { name = "logging", version = "1.5.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "logging", source = "hex", outer_checksum = "BC5F18CE5DD9686100229FE5409BDC3DD5C46D5A7DF2F804AD2D8F0DD6C5060E" },
+  { name = "simplifile", version = "2.4.0", build_tools = ["gleam"], requirements = ["filepath", "gleam_stdlib"], otp_app = "simplifile", source = "hex", outer_checksum = "7C18AFA4FED0B4CE1FA5B0B4BAC1FA1744427054EA993565F6F3F82E5453170D" },
+  { name = "snag", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "snag", source = "hex", outer_checksum = "274F41D6C3ECF99F7686FDCE54183333E41D2C1CA5A3A673F9A8B2C7A4401077" },
+  { name = "tom", version = "2.1.0", build_tools = ["gleam"], requirements = ["gleam_stdlib", "gleam_time"], otp_app = "tom", source = "hex", outer_checksum = "DCF04CB7AB35D58CFC598C66EA2E1816D160759802C89B2BA6238780D59BC256" },
 ]
 
 [requirements]
-gleam_erlang = { version = "~> 0.25" }
-gleam_otp = { version = "~> 0.10" }
-gleam_stdlib = { version = "~> 0.34 or ~> 1.0" }
+gleam_erlang = { version = "~> 1.0" }
+gleam_otp = { version = "~> 1.0" }
+gleam_stdlib = { version = "~> 1.0" }
+gleescript = { version = ">= 1.4.0 and < 2.0.0" }
 gleeunit = { version = "~> 1.0" }
-glisten = { version = "~> 2.0" }
+glisten = { version = "~> 9.0" }

--- a/solutions/gleam/01-at4/code/src/main.gleam
+++ b/solutions/gleam/01-at4/code/src/main.gleam
@@ -2,23 +2,22 @@ import gleam/io
 
 import gleam/erlang/process
 import gleam/option.{None}
-import gleam/otp/actor
 import glisten
 
 pub fn main() {
   // Ensures gleam doesn't complain about unused imports in stage 1 (feel free to remove this!)
-  let _ = glisten.handler
-  let _ = glisten.serve
+  let _ = glisten.new
+  let _ = glisten.start
+  let _ = glisten.continue
   let _ = process.sleep_forever
-  let _ = actor.continue
   let _ = None
 
   let assert Ok(_) =
-    glisten.handler(fn(_conn) { #(Nil, None) }, fn(_msg, state, _conn) {
+    glisten.new(fn(_conn) { #(Nil, None) }, fn(state, _msg, _conn) {
       io.println("Received message!")
-      actor.continue(state)
+      glisten.continue(state)
     })
-    |> glisten.serve(4221)
+    |> glisten.start(4221)
 
   process.sleep_forever()
 }

--- a/solutions/gleam/01-at4/code/your_program.sh
+++ b/solutions/gleam/01-at4/code/your_program.sh
@@ -15,10 +15,11 @@ set -e # Exit early if any commands fail
 (
   cd "$(dirname "$0")" # Ensure compile steps are run within the repository directory
   gleam build
+  gleam run -m gleescript
 )
 
 # Copied from .codecrafters/run.sh
 #
 # - Edit this to change how your program runs locally
 # - Edit .codecrafters/run.sh to change how your program runs remotely
-exec gleam run --no-print-progress --module main -- "$@"
+exec "$(dirname "$0")/main" "$@"

--- a/solutions/gleam/01-at4/diff/src/main.gleam.diff
+++ b/solutions/gleam/01-at4/diff/src/main.gleam.diff
@@ -1,17 +1,16 @@
-@@ -1,29 +1,24 @@
+@@ -1,28 +1,23 @@
  import gleam/io
 
  import gleam/erlang/process
  import gleam/option.{None}
- import gleam/otp/actor
  import glisten
 
  pub fn main() {
    // Ensures gleam doesn't complain about unused imports in stage 1 (feel free to remove this!)
-   let _ = glisten.handler
-   let _ = glisten.serve
+   let _ = glisten.new
+   let _ = glisten.start
+   let _ = glisten.continue
    let _ = process.sleep_forever
-   let _ = actor.continue
    let _ = None
 
 -  // You can use print statements as follows for debugging, they'll be visible when running tests.
@@ -20,19 +19,19 @@
 -  // TODO: Uncomment the code below to pass the first stage
 -  //
 -  // let assert Ok(_) =
--  //   glisten.handler(fn(_conn) { #(Nil, None) }, fn(_msg, state, _conn) {
+-  //   glisten.new(fn(_conn) { #(Nil, None) }, fn(state, _msg, _conn) {
 -  //     io.println("Received message!")
--  //     actor.continue(state)
+-  //     glisten.continue(state)
 -  //   })
--  //   |> glisten.serve(4221)
+-  //   |> glisten.start(4221)
 -  //
 -  // process.sleep_forever()
 +  let assert Ok(_) =
-+    glisten.handler(fn(_conn) { #(Nil, None) }, fn(_msg, state, _conn) {
++    glisten.new(fn(_conn) { #(Nil, None) }, fn(state, _msg, _conn) {
 +      io.println("Received message!")
-+      actor.continue(state)
++      glisten.continue(state)
 +    })
-+    |> glisten.serve(4221)
++    |> glisten.start(4221)
 +
 +  process.sleep_forever()
  }

--- a/starter_templates/gleam/code/.codecrafters/compile.sh
+++ b/starter_templates/gleam/code/.codecrafters/compile.sh
@@ -9,3 +9,4 @@
 set -e # Exit on failure
 
 gleam build
+gleam run -m gleescript

--- a/starter_templates/gleam/code/.codecrafters/run.sh
+++ b/starter_templates/gleam/code/.codecrafters/run.sh
@@ -8,4 +8,4 @@
 
 set -e # Exit on failure
 
-exec gleam run --no-print-progress --module main -- "$@"
+exec "$(dirname "$0")/main" "$@"

--- a/starter_templates/gleam/code/.gitignore
+++ b/starter_templates/gleam/code/.gitignore
@@ -2,3 +2,4 @@
 *.ez
 /build
 erl_crash.dump
+main

--- a/starter_templates/gleam/code/gleam.toml
+++ b/starter_templates/gleam/code/gleam.toml
@@ -1,14 +1,15 @@
-name = "codecrafters_http_server"
+name = "main"
 version = "1.0.0"
 
 # For a full reference of all the available options, you can have a look at
 # https://gleam.run/writing-gleam/gleam-toml/.
 
 [dependencies]
-gleam_stdlib = "~> 0.34 or ~> 1.0"
-gleam_erlang = "~> 0.25"
-gleam_otp = "~> 0.10"
-glisten = "~> 2.0"
+gleam_stdlib = "~> 1.0"
+gleam_erlang = "~> 1.0"
+gleam_otp = "~> 1.0"
+glisten = "~> 9.0"
 
 [dev-dependencies]
+gleescript = ">= 1.4.0 and < 2.0.0"
 gleeunit = "~> 1.0"

--- a/starter_templates/gleam/code/manifest.toml
+++ b/starter_templates/gleam/code/manifest.toml
@@ -2,16 +2,25 @@
 # You typically do not need to edit this file
 
 packages = [
-  { name = "gleam_erlang", version = "0.25.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_erlang", source = "hex", outer_checksum = "054D571A7092D2A9727B3E5D183B7507DAB0DA41556EC9133606F09C15497373" },
-  { name = "gleam_otp", version = "0.10.0", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_stdlib"], otp_app = "gleam_otp", source = "hex", outer_checksum = "0B04FE915ACECE539B317F9652CAADBBC0F000184D586AAAF2D94C100945D72B" },
-  { name = "gleam_stdlib", version = "0.39.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "2D7DE885A6EA7F1D5015D1698920C9BAF7241102836CE0C3837A4F160128A9C4" },
-  { name = "gleeunit", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "F7A7228925D3EE7D0813C922E062BFD6D7E9310F0BEE585D3A42F3307E3CFD13" },
-  { name = "glisten", version = "2.0.0", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_otp", "gleam_stdlib"], otp_app = "glisten", source = "hex", outer_checksum = "CF3A9383E9BA4A8CBAF2F7B799716290D02F2AC34E7A77556B49376B662B9314" },
+  { name = "argv", version = "1.1.0", build_tools = ["gleam"], requirements = [], otp_app = "argv", source = "hex", outer_checksum = "3277D100448BDB4A29B6D58C0F36F631CBC349E8BDD09766C6309DF202831140" },
+  { name = "filepath", version = "1.1.2", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "filepath", source = "hex", outer_checksum = "B06A9AF0BF10E51401D64B98E4B627F1D2E48C154967DA7AF4D0914780A6D40A" },
+  { name = "gleam_erlang", version = "1.3.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_erlang", source = "hex", outer_checksum = "1124AD3AA21143E5AF0FC5CF3D9529F6DB8CA03E43A55711B60B6B7B3874375C" },
+  { name = "gleam_otp", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_stdlib"], otp_app = "gleam_otp", source = "hex", outer_checksum = "BA6A294E295E428EC1562DC1C11EA7530DCB981E8359134BEABC8493B7B2258E" },
+  { name = "gleam_stdlib", version = "1.0.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "960090C2FB391784BB34267B099DC9315CC1B1F6013E7415BC763CEF1905D7D3" },
+  { name = "gleam_time", version = "1.8.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_time", source = "hex", outer_checksum = "533D8723774D61AD4998324F5DD1DABDCDBFABAFB9E87CB5D03C6955448FC97D" },
+  { name = "gleescript", version = "1.5.2", build_tools = ["gleam"], requirements = ["argv", "filepath", "gleam_erlang", "gleam_stdlib", "simplifile", "snag", "tom"], otp_app = "gleescript", source = "hex", outer_checksum = "27AC58481742ED29D9B37C506F78958A8AD798750A79ED08C8F8AFBA8F23563B" },
+  { name = "gleeunit", version = "1.10.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "254B697FE72EEAD7BF82E941723918E421317813AC49923EE76A18C788C61E72" },
+  { name = "glisten", version = "9.0.1", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_otp", "gleam_stdlib", "logging"], otp_app = "glisten", source = "hex", outer_checksum = "7795AA50830656F3A0316A6B26595F893C83272DA901B3405E31339CAA31A10B" },
+  { name = "logging", version = "1.5.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "logging", source = "hex", outer_checksum = "BC5F18CE5DD9686100229FE5409BDC3DD5C46D5A7DF2F804AD2D8F0DD6C5060E" },
+  { name = "simplifile", version = "2.4.0", build_tools = ["gleam"], requirements = ["filepath", "gleam_stdlib"], otp_app = "simplifile", source = "hex", outer_checksum = "7C18AFA4FED0B4CE1FA5B0B4BAC1FA1744427054EA993565F6F3F82E5453170D" },
+  { name = "snag", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "snag", source = "hex", outer_checksum = "274F41D6C3ECF99F7686FDCE54183333E41D2C1CA5A3A673F9A8B2C7A4401077" },
+  { name = "tom", version = "2.1.0", build_tools = ["gleam"], requirements = ["gleam_stdlib", "gleam_time"], otp_app = "tom", source = "hex", outer_checksum = "DCF04CB7AB35D58CFC598C66EA2E1816D160759802C89B2BA6238780D59BC256" },
 ]
 
 [requirements]
-gleam_erlang = { version = "~> 0.25" }
-gleam_otp = { version = "~> 0.10" }
-gleam_stdlib = { version = "~> 0.34 or ~> 1.0" }
+gleam_erlang = { version = "~> 1.0" }
+gleam_otp = { version = "~> 1.0" }
+gleam_stdlib = { version = "~> 1.0" }
+gleescript = { version = ">= 1.4.0 and < 2.0.0" }
 gleeunit = { version = "~> 1.0" }
-glisten = { version = "~> 2.0" }
+glisten = { version = "~> 9.0" }

--- a/starter_templates/gleam/code/src/main.gleam
+++ b/starter_templates/gleam/code/src/main.gleam
@@ -2,15 +2,14 @@ import gleam/io
 
 import gleam/erlang/process
 import gleam/option.{None}
-import gleam/otp/actor
 import glisten
 
 pub fn main() {
   // Ensures gleam doesn't complain about unused imports in stage 1 (feel free to remove this!)
-  let _ = glisten.handler
-  let _ = glisten.serve
+  let _ = glisten.new
+  let _ = glisten.start
+  let _ = glisten.continue
   let _ = process.sleep_forever
-  let _ = actor.continue
   let _ = None
 
   // You can use print statements as follows for debugging, they'll be visible when running tests.
@@ -19,11 +18,11 @@ pub fn main() {
   // TODO: Uncomment the code below to pass the first stage
   //
   // let assert Ok(_) =
-  //   glisten.handler(fn(_conn) { #(Nil, None) }, fn(_msg, state, _conn) {
+  //   glisten.new(fn(_conn) { #(Nil, None) }, fn(state, _msg, _conn) {
   //     io.println("Received message!")
-  //     actor.continue(state)
+  //     glisten.continue(state)
   //   })
-  //   |> glisten.serve(4221)
+  //   |> glisten.start(4221)
   //
   // process.sleep_forever()
 }


### PR DESCRIPTION
CC-2274: Upgrade Gleam to v0.16

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Upgrades the Gleam toolchain and multiple core dependencies, plus changes how the executable is produced and invoked, which could break compilation or runtime behavior in the starter/solution environments if any assumptions changed.
> 
> **Overview**
> Upgrades the Gleam starter/solution environment to `gleam-1.16` and updates dependency versions (notably `glisten` to `~> 9.0`), regenerating `manifest.toml` accordingly.
> 
> Switches the CodeCrafters compile/run flow to build a standalone `main` executable via `gleescript` (`gleam run -m gleescript`) and then execute `./main` instead of `gleam run`, adding `main` to `.gitignore`.
> 
> Updates the starter/solution `main.gleam` examples to the newer `glisten` API (`new`/`start`/`continue`) and adds a new `dockerfiles/gleam-1.16.Dockerfile` for the updated buildpack image.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b769b55e650fa42956ab42df4ccdb4ef1ac3569a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->